### PR TITLE
75569 show field names in validation errors

### DIFF
--- a/src/utils/wrapMethodSafe.ts
+++ b/src/utils/wrapMethodSafe.ts
@@ -30,8 +30,9 @@ export function wrapMethodSafe<T, R>(
             input = handlerInfo.methodConfig.request.parse(input);
           }
           catch (err) {
-            if (err instanceof ZodError)
-              throw new Error(`Invalid request type: ${err.issues.map((i) => i.message).join(',')}`);
+            if (err instanceof ZodError) {
+              throw new Error(`Invalid request type: ${err.issues.map((i) => `${i.message} (${i.path.join('.')})`).join(', ')}`);
+            }
 
             throw err;
           }

--- a/src/utils/wrapMethodSafe.ts
+++ b/src/utils/wrapMethodSafe.ts
@@ -31,7 +31,7 @@ export function wrapMethodSafe<T, R>(
           }
           catch (err) {
             if (err instanceof ZodError) {
-              throw new Error(`Invalid request type: ${err.issues.map((i) => `${i.message} (${i.path.join('.')})`).join(', ')}`);
+              throw new Error(`Error parsing request fields: ${err.issues.map((i) => `${i.path.join('.')} (${i.message})`).join(', ')}`);
             }
 
             throw err;


### PR DESCRIPTION
**BEFORE:**
`Invalid request type: Required,Required,Invalid input,Expected number, received string`

**AFTER:**
`Error parsing request fields: reason.text (Required), data (Required), value (Invalid input), numericValue (Expected number, received string)`